### PR TITLE
docs: add release strategy to agile standards

### DIFF
--- a/.agent/workflows/agile-standards.md
+++ b/.agent/workflows/agile-standards.md
@@ -44,11 +44,19 @@ Maintain the following artifacts throughout the lifecycle:
     - [ ] **How to Test**: Clear steps for verification.
 
 
-## 6. Merge Standards
+## 6. Release Strategy (CD)
+- [ ] **Promotion**: `developing` -> `main`.
+- [ ] **Trigger**: All tests passed on `developing`.
+- [ ] **Process**:
+    - [ ] Open Pull Request from `developing` to `main`.
+    - [ ] Title Format: `release: <description>`.
+    - [ ] No direct commits to `main` allowed.
+
+## 7. Merge Standards
 - [ ] **Conflict Free**: PR can be merged if there are no conflicts.
 - [ ] **Cleanup**: Delete the feature branch (locally and remotely) after successful merge.
 
-## 7. Definition of Done (DoD)
+## 8. Definition of Done (DoD)
 - [ ] **Verification**:
     - [ ] Test suite passing.
     - [ ] Linting checks passing.


### PR DESCRIPTION
## 🔗 Related Issues
- Relates to user request for CD release strategy.

## 🛠 Modifications
- Added **Release Strategy (CD)** section to Agile Standards.
- Defined process for promoting `developing` to `main`.
- Renumbered subsequent sections in `agile-standards.md`.

## 🧪 How to Test
1. Verified file content locally.
2. Verified branch creation (`feat/release-strategy`).

## ✅ Definition of Done
- [x] Code passes all tests (Documentation only).
- [x] Code passes all linting/formatting checks.
- [x] Documentation updated.
- [x] Backlog updated.
