### PR TITLE
docs: enforce documentation first rule

### DIFF
--- a/.agent/workflows/agile-standards.md
+++ b/.agent/workflows/agile-standards.md
@@ -12,6 +12,9 @@ Follow this workflow ensuring all work adheres to "The Band Project" standards.
 
 ## 2. Definition of Ready (DoR) Check
 Before moving a task to "In Progress":
+- [ ] **Documentation First**:
+    - [ ] Update `docs/*.md` (e.g., `requirements.md`, `sdd.md`) before creating the issue.
+    - [ ] **Reference**: Description MUST link to docs (e.g., "Implement Req 1.1 as detailed in `docs/requirements.md`").
 - [ ] **Hierarchy Check**: Confirm strict hierarchy: `Epic -> User Story -> Task`.
 - [ ] **Governance**: Ensure work is associated with "The Band Project" ecosystem.
 - [ ] **readiness**:


### PR DESCRIPTION
## 🔗 Related Issues
- Relates to user request for "Documentation First" standard.

## 🛠 Modifications
- **Documentation First Rule**: Added new standard to **Definition of Ready (DoR)** in `agile-standards.md`.
    - Requires `docs/*.md` updates before issue creation.
    - Requires issue description to reference these docs.

## 🧪 How to Test
1. Verified file content locally.
2. Verified branch creation (`feat/docs-first-rule`).

## ✅ Definition of Done
- [x] Code passes all tests.
- [x] Code passes all linting/formatting checks.
- [x] Documentation updated.
- [x] Backlog updated.
