### PR TITLE
docs: enforce backlog release tracking

### DIFF
--- a/.agent/workflows/agile-standards.md
+++ b/.agent/workflows/agile-standards.md
@@ -31,6 +31,10 @@ Before moving a task to "In Progress":
 Maintain the following artifacts throughout the lifecycle:
 - [ ] `task.md`: For detailed task tracking.
 - [ ] `implementation_plan.md`: For technical planning and review.
+- [ ] `docs/backlog.md`: Must include **Releases** section with:
+    - PR Number & Link
+    - Description
+    - Commit SHA & Link
 
 ## 4. Implementation Standards
 - [ ] **TDD**: Code must pass all tests.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -2,6 +2,13 @@
 
 This document is automatically synchronized with GitHub Issues. Last updated: 2025-12-31 19:17:51
 
+## 🚀 Releases
+| PR # | Description | Commit |
+| :--- | :--- | :--- |
+| [#12](https://github.com/The-Band-Solution/eo_lib/pull/12) | docs: enforce documentation first rule | [afe61e8](https://github.com/The-Band-Solution/eo_lib/commit/afe61e8) |
+| [#11](https://github.com/The-Band-Solution/eo_lib/pull/11) | docs: add Release Strategy to agile standards | [ba98dab](https://github.com/The-Band-Solution/eo_lib/commit/ba98dab) |
+| [#9](https://github.com/The-Band-Solution/eo_lib/pull/9) | docs: implement GitFlow standards | [de1b7d1](https://github.com/The-Band-Solution/eo_lib/commit/de1b7d1) |
+
 ## 📋 Master Issue List
 Visão geral de todas as demandas, seus estados e executores.
 


### PR DESCRIPTION
## 🔗 Related Issues
- Relates to user request for Backlog Release tracking.

## 🛠 Modifications
- **Backlog**: Added `🚀 Releases` section to `docs/backlog.md` with PR #, Description, and Commit columns.
- **Standards**: Updated `agile-standards.md` to mandate this section in the backlog.
- **History**: Populated the releases table with recent changes (PRs #9, #11, #12).

## 🧪 How to Test
1. Check `docs/backlog.md` for the new table.
2. Check `agile-standards.md` for the new requirement.

## ✅ Definition of Done
- [x] Code passes all tests.
- [x] Code passes all linting/formatting checks.
- [x] Documentation updated.
- [x] Backlog updated.
