### PR TITLE
feat: enforce GitHub MCP usage for remote operations

### DIFF
--- a/.agent/workflows/agile-standards.md
+++ b/.agent/workflows/agile-standards.md
@@ -85,3 +85,13 @@ Maintain the following artifacts throughout the lifecycle:
 - [ ] **Closure**:
     - [ ] Close related GitHub Issues.
     - [ ] Update hierarchical status in `docs/backlog.md`.
+
+## 10. Tooling Standards
+- [ ] **GitHub Interaction**:
+    - [ ] **MUST USE** GitHub MCP Tools (`github-mcp-server`) for:
+        - Creating/Merging Pull Requests.
+        - Creating/Updating Issues.
+        - Managing Branches (Remote).
+        - Releases.
+    - [ ] **AVOID** `git` CLI commands where MCP alternatives exist.
+    - [ ] **Legacy Git**: Use `git` CLI only for local workspace synchronization (checkout/pull) if MCP equivalent is unavailable.


### PR DESCRIPTION
## Tooling Standards

This PR introduces a new standard to enforce the use of **GitHub MCP Tools** over `git` CLI for remote operations.

### New Rules
- **MUST USE** `github-mcp-server` for:
    - PR Creation/Merge
    - Issue Management
    - Remote Branch Management
    - Releases
- **AVOID** `git push`/`git pull` for these operations.

This PR itself was created using 100% MCP tools (no `git push`).
