### PR TITLE
feat: update release workflow to support tag-based versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,13 @@ jobs:
         python -m pip install --upgrade pip
         pip install hatch
         
+    - name: Set Release Version (from Tag)
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        TAG_NAME=${GITHUB_REF#refs/tags/}
+        echo "Updating version to $TAG_NAME"
+        python scripts/bump_version.py $TAG_NAME
+        
     - name: Build package
       run: hatch build
       

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 
 
-def bump_version(file_path: str, part: str = "patch"):
+def bump_version(file_path: str, argument: str = "patch"):
     path = Path(file_path)
     content = path.read_text()
 
@@ -15,19 +15,27 @@ def bump_version(file_path: str, part: str = "patch"):
         print(f"Error: version not found in {file_path}")
         sys.exit(1)
 
-    major, minor, patch = map(int, match.groups())
+    # Check if argument is a specific version (X.Y.Z)
+    if re.match(r"^\d+\.\d+\.\d+$", argument):
+        new_version = argument
+    else:
+        major, minor, patch = map(int, match.groups())
 
-    if part == "major":
-        major += 1
-        minor = 0
-        patch = 0
-    elif part == "minor":
-        minor += 1
-        patch = 0
-    else:  # patch
-        patch += 1
+        if argument == "major":
+            major += 1
+            minor = 0
+            patch = 0
+        elif argument == "minor":
+            minor += 1
+            patch = 0
+        elif argument == "patch":
+            patch += 1
+        else:
+            print(f"Error: Invalid argument '{argument}'. Must be 'major', 'minor', 'patch', or a specific version like '1.2.3'.")
+            sys.exit(1)
 
-    new_version = f"{major}.{minor}.{patch}"
+        new_version = f"{major}.{minor}.{patch}"
+
     new_content = re.sub(pattern, f'version = "{new_version}"', content)
 
     path.write_text(new_content)
@@ -36,5 +44,9 @@ def bump_version(file_path: str, part: str = "patch"):
 
 if __name__ == "__main__":
     # Default to bumping patch
-    part = sys.argv[1] if len(sys.argv) > 1 else "patch"
-    bump_version("pyproject.toml", part)
+    argument = sys.argv[1] if len(sys.argv) > 1 else "patch"
+    # Strip 'v' prefix if present (e.g., v0.2.3 -> 0.2.3)
+    if argument.startswith("v"):
+        argument = argument[1:]
+    
+    bump_version("pyproject.toml", argument)


### PR DESCRIPTION
## Release Workflow Update

Updates the release process to align with tag-based triggers.

### Changes
- **Release Workflow**: `.github/workflows/release.yml` now extracts the version from the git tag (e.g., `v0.2.3` -> `0.2.3`) and runs `scripts/bump_version.py` to sync `pyproject.toml` before building.
- **Bump Script**: Updated `scripts/bump_version.py` to accept explicit version strings (e.g., `0.2.3`), allowing it to set the version directly as requested by CI.

This enables a workflow where creating a git tag triggers the release, sets the correct version in the package file, and publishes the artifact.
