### PR TITLE
chore: implement latest tag support in workflows and standards

### DIFF
--- a/.agent/workflows/agile-standards.md
+++ b/.agent/workflows/agile-standards.md
@@ -69,11 +69,12 @@ Maintain the following artifacts throughout the lifecycle:
     - [ ] Open Pull Request from `developing` to `main`.
     - [ ] Title Format: `release: <description>`.
     - [ ] No direct commits to `main` allowed.
-    - [ ] **Versioning**:
-        - [ ] **DO NOT** run `bump_version.py` locally.
-        - [ ] **Create Tag**: `git tag vX.Y.Z` (at end of each feature/fix/release).
-        - [ ] **Push Tag**: `git push origin vX.Y.Z`.
-        - [ ] **CI/CD**: GitHub Action handles version bump & publish.
+        - [ ] **Versioning**:
+            - [ ] **DO NOT** run `bump_version.py` locally.
+            - [ ] **Create Tag**: `git tag vX.Y.Z` (at end of each feature/fix/release).
+            - [ ] **Update Latest**: `git tag -f latest` and `git push origin -f latest` (at end of each feature/fix/bug).
+            - [ ] **Push Tag**: `git push origin vX.Y.Z`.
+            - [ ] **CI/CD**: GitHub Action handles version bump & publish.
 
 ## 8. Merge Standards
 - [ ] **Conflict Free**: PR can be merged if there are no conflicts.
@@ -90,7 +91,7 @@ Maintain the following artifacts throughout the lifecycle:
 - [ ] **Closure**:
     - [ ] Close related GitHub Issues.
     - [ ] Update hierarchical status in `docs/backlog.md`.
-    - [ ] **Versioning**: Tag the release (see Section 7) after Feature/Fix/Bug closure.
+    - [ ] **Versioning**: Tag the release and update `latest` tag (see Section 7) after Feature/Fix/Bug closure.
 
 ## 10. Tooling Standards
 - [ ] **GitHub Interaction**:

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -18,6 +18,9 @@ def bump_version(file_path: str, argument: str = "patch"):
     # Check if argument is a specific version (X.Y.Z)
     if re.match(r"^\d+\.\d+\.\d+$", argument):
         new_version = argument
+    elif argument == "latest":
+        print(f"Tag 'latest' detected. Keeping current version in {file_path}.")
+        return
     else:
         major, minor, patch = map(int, match.groups())
 


### PR DESCRIPTION
## Latest Tag Support

This PR updates our workflows and standards to support and mandate the use of the `latest` tag.

### Changes
- **scripts/bump_version.py**: Added support for the `latest` argument. When `latest` is passed, the script exits without modifying `pyproject.toml`, allowing the "latest" tag to be built using the current version in the code.
- **agile-standards.md**: Updated Section 7 (Release Strategy) and Section 9 (DoD) to mandate updating the `latest` tag after every feature, fix, or bug.

Process:
- `git tag -f latest`
- `git push origin -f latest`
