### PR TITLE
feat: Implement Database Indexing for Entities

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -32,7 +32,18 @@
 - **FR-05-C**: The system must allow updating a Role.
 - **FR-05-D**: The system must allow deleting a Role.
 
-### FR-06: Configuration
+### FR-06: Organization Management
+- **FR-06-A**: The system must allow creating an Organization with `name`, `description`, and `short_name`.
+- **FR-06-B**: The system must allow listing all Organizations.
+- **FR-06-C**: The system must allow updating Organization metadata.
+
+### FR-07: Organizational Unit Management
+- **FR-07-A**: The system must allow creating an Organizational Unit associated with an Organization.
+- **FR-07-B**: Organizational Units must support a hierarchical structure (`parent_id`).
+- **FR-07-C**: The system must allow listing all Units of an Organization.
+- **FR-07-D**: The system must allow updating Unit metadata and its parent.
+
+### FR-08: Configuration
 - **FR-02-A**: The database connection string must be configurable via Environment Variables or a Config object passed at initialization.
 
 ## 2. Non-Functional Requirements (NFR)
@@ -47,6 +58,7 @@
 
 ### NFR-03: Performance
 - **NFR-03-A**: Database connections must be pooled and managed efficiently (Singleton/Pool).
+- **NFR-03-B**: The system must define indexes for frequently queried columns (e.g., names, foreign keys, status) to optimize read performance.
 
 ## 3. Constraints
 - Must use PostgreSQL.

--- a/docs/specifications.md
+++ b/docs/specifications.md
@@ -51,6 +51,19 @@
 | `project_id` | `INTEGER` | `FK(projects.id)`, `PK` | Project Link |
 | `team_id` | `INTEGER` | `FK(teams.id)`, `PK` | Team Link |
 
+### 2.3 Data Indexing Strategy
+To ensure high performance for read operations, the following indexes must be implemented:
+
+| Entity | Indexed Columns | Rationale |
+|--------|-----------------|-----------|
+| **Person** | `name`, `identification_id` | Frequent search by name and ID. |
+| **Team** | `name` | Frequent lookup by name. |
+| **TeamMember** | `role`, `person_id`, `team_id` | optimizing membership queries. FKs usually indexed. |
+| **Initiative** | `name`, `status`, `start_date`, `end_date`, `initiative_type_id` | filtering by status/dates and type. |
+| **InitiativeType** | `name` | Lookup by name. |
+| **Organization** | `name`, `short_name` | Search by names. |
+| **OrganizationalUnit** | `name`, `organization_id`, `parent_id` | Hierarchical queries and name search. |
+
 ## 2. API Specifications (Public Interface)
 
 ### Class: `PersonController`

--- a/src/eo_lib/domain/entities/initiative.py
+++ b/src/eo_lib/domain/entities/initiative.py
@@ -66,13 +66,13 @@ class Initiative(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String, unique=True, index=True, nullable=False)
-    status = Column(String, default="active")
+    status = Column(String, default="active", index=True)
     description = Column(Text, nullable=True)
-    start_date = Column(DateTime, nullable=True)
-    end_date = Column(DateTime, nullable=True)
+    start_date = Column(DateTime, nullable=True, index=True)
+    end_date = Column(DateTime, nullable=True, index=True)
 
     initiative_type_id = Column(
-        Integer, ForeignKey("initiative_types.id"), nullable=True
+        Integer, ForeignKey("initiative_types.id"), index=True, nullable=True
     )
     organization_id = Column(Integer, ForeignKey("organizations.id"), nullable=True)
     parent_id = Column(Integer, ForeignKey("initiatives.id"), nullable=True)

--- a/src/eo_lib/domain/entities/organizational_unit.py
+++ b/src/eo_lib/domain/entities/organizational_unit.py
@@ -31,8 +31,8 @@ class OrganizationalUnit(Base):
     description = Column(Text, nullable=True)
     short_name = Column(String, index=True, nullable=True)
 
-    organization_id = Column(Integer, ForeignKey("organizations.id"), nullable=False)
-    parent_id = Column(Integer, ForeignKey("organizational_units.id"), nullable=True)
+    organization_id = Column(Integer, ForeignKey("organizations.id"), index=True, nullable=False)
+    parent_id = Column(Integer, ForeignKey("organizational_units.id"), index=True, nullable=True)
 
     # Relationships
     organization = relationship("Organization", back_populates="units")

--- a/src/eo_lib/domain/entities/person.py
+++ b/src/eo_lib/domain/entities/person.py
@@ -27,7 +27,7 @@ class Person(Base):
     __tablename__ = "persons"
 
     id = Column(Integer, primary_key=True, index=True)
-    name = Column(String, nullable=False)
+    name = Column(String, nullable=False, index=True)
     identification_id = Column(String, unique=True, index=True, nullable=True)
     birthday = Column(Date, nullable=True)
 

--- a/src/eo_lib/domain/entities/team.py
+++ b/src/eo_lib/domain/entities/team.py
@@ -90,9 +90,9 @@ class TeamMember(Base):
     __tablename__ = "team_members"
 
     id = Column(Integer, primary_key=True, index=True)
-    person_id = Column(Integer, ForeignKey("persons.id"), nullable=False)
-    team_id = Column(Integer, ForeignKey("teams.id"), nullable=False)
-    role_id = Column(Integer, ForeignKey("roles.id"), nullable=True)
+    person_id = Column(Integer, ForeignKey("persons.id"), index=True, nullable=False)
+    team_id = Column(Integer, ForeignKey("teams.id"), index=True, nullable=False)
+    role_id = Column(Integer, ForeignKey("roles.id"), index=True, nullable=True)
     start_date = Column(DateTime, default=func.now())
     end_date = Column(DateTime, nullable=True)
 


### PR DESCRIPTION
## Description
Implemented database indexes for improved performance as requested in #31.

## Changes
- Added indexes to `Person`, `Team`, `Initiative`, `Organization`, `OrganizationalUnit` entities.
- Updated `docs/requirements.md` and `docs/specifications.md`.

## Related Issues
Closes #31

## How to Test
1. Run `pytest`.
2. Verify schema (e.g. using `sqlacodegen` or checking models).